### PR TITLE
Publicizes `MainQueueScheduler.init`

### DIFF
--- a/Sources/ViewStore/MainQueueScheduler.swift
+++ b/Sources/ViewStore/MainQueueScheduler.swift
@@ -37,7 +37,7 @@ public final class MainQueueScheduler: Scheduler {
 
     /// Creates a new `MainQueueScheduler`.
     /// - Parameter type: The scheduler type that determines the timing of work execute.
-    init(type: SchedulerType = .default) {
+    public init(type: SchedulerType = .default) {
         self.type = type
     }
 


### PR DESCRIPTION
## What it Does
We can‘t initialize this from a consumer right now, so just publicizing it.

## How I Tested
Integrated the package in a sample project. 

## Notes
N/A

## Screenshot
N/A
