### PR TITLE
Adds default `Never`  action type

### DIFF
--- a/Sources/ViewStore/ViewStore.swift
+++ b/Sources/ViewStore/ViewStore.swift
@@ -23,3 +23,8 @@ public protocol ViewStore: ObservableObject {
     /// - Parameter action: The action to perform.
     func send(_ action: Action)
 }
+
+/// Default implementation that allows stores with no actions to send to ignore this function requirement in the protocol.
+public extension ViewStore {
+    func send(_ action: Never) {}
+}


### PR DESCRIPTION
## What it Does
For view stores that don’t have actions associated with them, this extension makes declaration and conformance much simpler. You basically just ignore the `Action` type and associated method all together.

## How I Tested

1. Commented out this extension and declared:

```swift
final class MyViewStore: ViewStore {
    var viewState = ""
}
```

2. Got a compiler error that I didn't fully implement the `ViewStore` protocol.
3. Uncommented the extension.
4. Compiler error went away.
## Notes
I believe it was @bcapps who originally authored this extension, so credit goes to him.
## Screenshot
N/A