### PR TITLE
Adds Publisher Option To MakeBinding Extension

### DIFF
--- a/Sources/ViewStore/ViewStore+BindingAdditions.swift
+++ b/Sources/ViewStore/ViewStore+BindingAdditions.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import CasePaths
+import Combine
 
 /// An extension on `ViewStore` that provides conveniences for creating `Binding`s.
 public extension ViewStore {
@@ -44,6 +45,30 @@ public extension ViewStore {
             self.viewState[keyPath: viewStateKeyPath] != nil
         } set: { value in
             self.send(actionCasePath.embed(()))
+        }
+    }
+    
+    /// Provides a mechanism for creating `Binding`s that send their value to a `PassthroughSubject`, leveraging `KeyPath`s to reduce duplication and errors.
+    /// - Parameters:
+    ///   - viewStateKeyPath: The `KeyPath` to the `ViewState` property that this binding wraps.
+    ///   - publisher: The publisher to send the value to.
+    func makeBinding<Value>(viewStateKeyPath: KeyPath<ViewState, Value>, publisher: PassthroughSubject<Value, Never>) -> Binding<Value> {
+        return .init {
+            self.viewState[keyPath: viewStateKeyPath]
+        } set: { value in
+            publisher.send(value)
+        }
+    }
+    
+    /// Provides a mechanism for creating `Binding`s that send their value to a `CurrentValueSubject`, leveraging `KeyPath`s to reduce duplication and errors.
+    /// - Parameters:
+    ///   - viewStateKeyPath: The `KeyPath` to the `ViewState` property that this binding wraps.
+    ///   - publisher: The publisher to send the value to.
+    func makeBinding<Value>(viewStateKeyPath: KeyPath<ViewState, Value>, publisher: CurrentValueSubject<Value, Never>) -> Binding<Value> {
+        return .init {
+            self.viewState[keyPath: viewStateKeyPath]
+        } set: { value in
+            publisher.send(value)
         }
     }
 }


### PR DESCRIPTION
## What it Does
Adds new extensions to the BindingAdditions to allow for passing in a publisher rather than an action.

## Notes
After seeing the use case of the ViewStore with no actions, I thought this would be a nice addition to condense the creation of bindings who's `set` sent a value to a publisher. In practice, rather than specifying a case path, you can now simply specify a publisher like so:

```swift
makeBinding(viewStateKeyPath: \.searchText, publisher: searchTextPublisher)
```

This is useful for either `ViewStore`s that don't have any actions, or for view stores that want to have `Binding` that doesn't use a publicized action.

I would've used `some Subject`, instead of one for Passthrough and one for CurrentValue,  but that's not out yet.