### PR TITLE
Adding ability to have a bool from a publisher with optional value

### DIFF
--- a/Sources/ViewStore/ViewStore+BindingAdditions.swift
+++ b/Sources/ViewStore/ViewStore+BindingAdditions.swift
@@ -57,7 +57,7 @@ public extension ViewStore {
             self.viewState[keyPath: viewStateKeyPath] != nil
         } set: { value in
             guard !value else {
-                return assertionFailure("Unexpectedly received 'true' from `makeBinding` Bool convenience setter.")
+                return assertionFailure("Unexpectedly received `true` from `makeBinding` Bool convenience setter.")
             }
             
             self.send(actionCasePath.embed(nil))

--- a/Sources/ViewStore/ViewStore+BindingAdditions.swift
+++ b/Sources/ViewStore/ViewStore+BindingAdditions.swift
@@ -48,6 +48,22 @@ public extension ViewStore {
         }
     }
     
+    /// Provides a mechanism for creating `Binding<Bool>`s based on the existence of a property on the `ViewState`, leveraging `KeyPath`s to reduce duplication and errors.
+    /// - Parameters:
+    ///   - viewStateKeyPath: The `KeyPath` to the optional `ViewState` property whose existence determines the wrapped value.
+    ///   - actionCasePath: The `CasePath` to the `Action` case associated with the `ViewState` property.
+    func makeBinding<Value>(viewStateKeyPath: KeyPath<ViewState, Value?>, actionCasePath: CasePath<Action, Value?>) -> Binding<Bool> {
+        return .init {
+            self.viewState[keyPath: viewStateKeyPath] != nil
+        } set: { value in
+            guard !value else {
+                return assertionFailure("Unexpectedly received 'true' from `makeBinding` Bool convenience setter.")
+            }
+            
+            self.send(actionCasePath.embed(nil))
+        }
+    }
+    
     /// Provides a mechanism for creating `Binding`s that send their value to a `PassthroughSubject`, leveraging `KeyPath`s to reduce duplication and errors.
     /// - Parameters:
     ///   - viewStateKeyPath: The `KeyPath` to the `ViewState` property that this binding wraps.


### PR DESCRIPTION
## What it Does
- Adds API to create a binding of type bool from a property that has an associated optional value.

## How I Tested
- Ran in my project to test out functionality.
