### PR TITLE
Primary associated types for the ViewStore protocol

### DIFF
--- a/Sources/ViewStore/ViewStore.swift
+++ b/Sources/ViewStore/ViewStore.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// A view store is an `ObservableObject` that allows us to separate view-specific logic and the rendering of a corresponding view in a way that is repeatable, prescriptive, flexible, and testable by default.
-public protocol ViewStore: ObservableObject {
+public protocol ViewStore<ViewState, Action>: ObservableObject {
 
     /// A container type for state associated with the corresponding view.
     associatedtype ViewState


### PR DESCRIPTION
## What it Does

This PR adds primary associated types to our ViewStore protocol. 

For more information and uses of primary associated types, see these resources:

- https://www.donnywals.com/what-are-primary-associated-types-in-swift-5-7/ 
- https://github.com/apple/swift-evolution/blob/main/proposals/0358-primary-associated-types-in-stdlib.md

## How I Tested

Made sure the test app still built 
Made sure the unit tests passed

