### PR TITLE
Fixing search text timing bug 

### DIFF
--- a/Example/Photos/PhotoListViewStore.swift
+++ b/Example/Photos/PhotoListViewStore.swift
@@ -63,7 +63,7 @@ final class PhotoListViewStore: ViewStore {
         let showsPhotosCountPublisher = self.showsPhotosCountPublisher.prepend(ViewState.initial.showsPhotoCount)
         let photoPublisher = provider.providePhotos().prepend([])
         let searchTextUIPublisher =  self.searchTextPublisher.prepend(ViewState.initial.searchText)
-        let searchTextPublisher = searchTextUIPublisher.debounce(for: .seconds(1), scheduler: scheduler)
+        let searchTextPublisher = searchTextUIPublisher.throttle(for: 1, scheduler: scheduler, latest: true)
 
         photoPublisher
             .combineLatest(showsPhotosCountPublisher, searchTextPublisher, searchTextUIPublisher)
@@ -74,7 +74,7 @@ final class PhotoListViewStore: ViewStore {
                     let navigationTitle = showsPhotosCount ? LocalizedStringKey("Photos \(filteredPhotos.count)") : ViewState.defaultNavigationTitle
                     return ViewState(status: .content(filteredPhotos), showsPhotoCount: showsPhotosCount, navigationTitle: navigationTitle, searchText: searchTextUI)
                 case let .failure(error):
-                    return ViewState(status: .error(error), showsPhotoCount: false, navigationTitle: ViewState.defaultNavigationTitle, searchText: searchText)
+                    return ViewState(status: .error(error), showsPhotoCount: false, navigationTitle: ViewState.defaultNavigationTitle, searchText: searchTextUI)
                 }
             }
             .receive(on: scheduler)

--- a/Example/Photos/PhotoListViewStore.swift
+++ b/Example/Photos/PhotoListViewStore.swift
@@ -31,7 +31,7 @@ final class PhotoListViewStore: ViewStore {
         let status: Status
         let showsPhotoCount: Bool
         let navigationTitle: LocalizedStringKey
-        fileprivate let searchText: String
+        let searchText: String
         
         init(status: PhotoListViewStore.ViewState.Status = .loading, showsPhotoCount: Bool = false, navigationTitle: LocalizedStringKey = ViewState.defaultNavigationTitle, searchText: String = "") {
             self.status = status

--- a/ExampleTests/ViewStoreTests.swift
+++ b/ExampleTests/ViewStoreTests.swift
@@ -41,4 +41,16 @@ final class ViewStoreTests: XCTestCase {
             XCTAssertTrue(photos[0].title.contains("2"))
         }
     }
+    
+    func testSearchProperlyFiltersAndSearchTextIsCorrect() {
+        let mock = MockItemProvider(photosCount: 3)
+        let scheduler = MainQueueScheduler(type: .test)
+        
+        let vs = PhotoListViewStore(provider: mock, scheduler: scheduler)
+        vs.send(.search("2"))
+        
+        scheduler.advance(by: 1)
+        
+        XCTAssertEqual(vs.viewState.searchText, "2")
+    }
 }

--- a/ExampleTests/ViewStoreTests.swift
+++ b/ExampleTests/ViewStoreTests.swift
@@ -44,12 +44,9 @@ final class ViewStoreTests: XCTestCase {
     
     func testSearchProperlyFiltersAndSearchTextIsCorrect() {
         let mock = MockItemProvider(photosCount: 3)
-        let scheduler = MainQueueScheduler(type: .test)
         
-        let vs = PhotoListViewStore(provider: mock, scheduler: scheduler)
+        let vs = PhotoListViewStore(provider: mock, scheduler: MainQueueScheduler(type: .synchronous))
         vs.send(.search("2"))
-        
-        scheduler.advance(by: 1)
         
         XCTAssertEqual(vs.viewState.searchText, "2")
     }


### PR DESCRIPTION
Fixes a small bug we introduced into the project, where the text in the search field on the view store only updates after a debounce of 1.

This also introduces a test to verify that case

You can test this by verifying the text field populates as you type, and that the filter does not occur "live" 