### PR TITLE
Swift 6 & Strict Concurrency

### DIFF
--- a/Example/Photos/With Stores/Banner Feature/MockBannerNetworkStateController.swift
+++ b/Example/Photos/With Stores/Banner Feature/MockBannerNetworkStateController.swift
@@ -43,11 +43,8 @@ final class MockBannerNetworkStateController {
                 do {
                     _ = try result.get()
                     return nil
-                } catch let error as NetworkError {
+                } catch let error {
                     return error
-                } catch {
-                    assertionFailure("unhandled error")
-                    return nil
                 }
             }
         }

--- a/Example/Photos/With Stores/Banner Feature/MockBannerNetworkStateController.swift
+++ b/Example/Photos/With Stores/Banner Feature/MockBannerNetworkStateController.swift
@@ -71,6 +71,7 @@ final class MockBannerNetworkStateController {
     
     /// Uploads a `Banner` to a fake server.
     /// - Parameter banner: The `Banner` to upload.
+    @MainActor
     func upload(banner: Banner) {
         self.publisher.send(.inProgress)
 

--- a/Example/Photos/With Stores/PhotoListViewStore.swift
+++ b/Example/Photos/With Stores/PhotoListViewStore.swift
@@ -18,7 +18,7 @@ final class PhotoListViewStore: Store {
 
     // MARK: - Store
 
-    struct State {
+    struct State: Sendable {
         
         /// Status defines the current status of the photo list view
         enum Status {

--- a/Example/Photos/With Stores/PhotoListViewStore.swift
+++ b/Example/Photos/With Stores/PhotoListViewStore.swift
@@ -33,7 +33,7 @@ final class PhotoListViewStore: Store {
         }
         
         /// Default navigation title for the view
-        fileprivate static let defaultNavigationTitle = LocalizedStringKey("Photos")
+        nonisolated(unsafe) fileprivate static let defaultNavigationTitle = LocalizedStringKey("Photos")
         
         /// Initial state of the photo list view store
         fileprivate static let initial = State()
@@ -45,7 +45,7 @@ final class PhotoListViewStore: Store {
         let showsPhotoCount: Bool
         
         /// Navigation title for the view
-        let navigationTitle: LocalizedStringKey
+        nonisolated(unsafe) let navigationTitle: LocalizedStringKey
         
         /// Search text entered by the user
         let searchText: String

--- a/ExampleTests/StoreTests.swift
+++ b/ExampleTests/StoreTests.swift
@@ -10,6 +10,7 @@ import XCTest
 @testable import Provider
 import Combine
 
+@MainActor
 final class StoreTests: XCTestCase {
 
     func testToggleShowsPhotoCount() throws {

--- a/Sources/Store/MainQueueScheduler.swift
+++ b/Sources/Store/MainQueueScheduler.swift
@@ -11,7 +11,8 @@ import SwiftUI
 
 /// Scheduler that allows you to either have a `default` implementation of the `DispatchQueue.main` scheduler,  a `synchronous` implementation that will immediately call back, a `test` scheduler for fine grained control of time, and an `animated` scheduler to drive animations.
 /// You will want to use this to avoid the behavior of `DispatchQueue.main`'s scheduler to schedule work asynchronously by default.
-public final class MainQueueScheduler: Scheduler {
+@MainActor
+public final class MainQueueScheduler: @preconcurrency Scheduler {
 
     /// Describes the characteristics of the scheduler.
     public enum SchedulerType: Equatable {

--- a/Sources/Store/MockStore.swift
+++ b/Sources/Store/MockStore.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 /// A generic object conforming to `Store` that simply returns the passed-in state. Useful in SwiftUI previews.
-public final class MockStore<State: Sendable, Action>: Store {
+public final class MockStore<State: Sendable, Action: Sendable>: Store {
     
     // MARK: - Store
 

--- a/Sources/Store/MockStore.swift
+++ b/Sources/Store/MockStore.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 /// A generic object conforming to `Store` that simply returns the passed-in state. Useful in SwiftUI previews.
-public final class MockStore<State, Action>: Store {
+public final class MockStore<State: Sendable, Action>: Store {
     
     // MARK: - Store
 

--- a/Sources/Store/ScopedStore.swift
+++ b/Sources/Store/ScopedStore.swift
@@ -10,7 +10,7 @@ import Combine
 import CasePaths
 
 /// A `Store` that's purpose is to allow clients of it to modify a parent's Store and one of it's sub-stores without having direct access to either store.
-public final class ScopedStore<State, Action>: Store {
+public final class ScopedStore<State: Sendable, Action>: Store {
     
     // MARK: - Store
     
@@ -83,7 +83,7 @@ public extension Store {
     ///   - stateKeyPath: The keypath to the property on the Parent's `State` that is managed by the substore.
     ///   - actionCasePath: The case path to an action on the Parent's `Store` that has the substore's action as the associated value that forwards to the substore.
     /// - Returns: A `Store` that is scoped to the specified state and action.
-    func scoped<Substate, Subaction>(stateKeyPath: KeyPath<State, Substate>, actionCasePath: CasePath<Action, Subaction>) -> any Store<Substate, Subaction> {
+    func scoped<Substate: Sendable, Subaction>(stateKeyPath: KeyPath<State, Substate>, actionCasePath: CasePath<Action, Subaction>) -> any Store<Substate, Subaction> {
         return ScopedStore(initial: state[keyPath: stateKeyPath], statePublisher: publishedState.map(stateKeyPath), action: { self.send(actionCasePath.embed($0)) })
     }
 }

--- a/Sources/Store/ScopedStore.swift
+++ b/Sources/Store/ScopedStore.swift
@@ -10,7 +10,7 @@ import Combine
 import CasePaths
 
 /// A `Store` that's purpose is to allow clients of it to modify a parent's Store and one of it's sub-stores without having direct access to either store.
-public final class ScopedStore<State: Sendable, Action>: Store {
+public final class ScopedStore<State: Sendable, Action: Sendable>: Store {
     
     // MARK: - Store
     
@@ -83,7 +83,7 @@ public extension Store {
     ///   - stateKeyPath: The keypath to the property on the Parent's `State` that is managed by the substore.
     ///   - actionCasePath: The case path to an action on the Parent's `Store` that has the substore's action as the associated value that forwards to the substore.
     /// - Returns: A `Store` that is scoped to the specified state and action.
-    func scoped<Substate: Sendable, Subaction>(stateKeyPath: KeyPath<State, Substate>, actionCasePath: CasePath<Action, Subaction>) -> any Store<Substate, Subaction> {
+    func scoped<Substate: Sendable, Subaction: Sendable>(stateKeyPath: KeyPath<State, Substate>, actionCasePath: CasePath<Action, Subaction>) -> any Store<Substate, Subaction> {
         return ScopedStore(initial: state[keyPath: stateKeyPath], statePublisher: publishedState.map(stateKeyPath), action: { self.send(actionCasePath.embed($0)) })
     }
 }

--- a/Sources/Store/Store.swift
+++ b/Sources/Store/Store.swift
@@ -13,7 +13,7 @@ import Combine
 public protocol Store<State, Action>: ObservableObject {
 
     /// A container type for state associated with the corresponding domain.
-    associatedtype State
+    associatedtype State: Sendable
 
     /// Usually represented as an `enum`, `Action` represents any functionality that a store can perform on-demand.
     associatedtype Action

--- a/Sources/Store/Store.swift
+++ b/Sources/Store/Store.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import Combine
 
 /// A store is an `ObservableObject` that allows us to separate business and/or view level logic and the rendering of views in a way that is repeatable, prescriptive, flexible, and testable by default.
+@MainActor
 public protocol Store<State, Action>: ObservableObject {
 
     /// A container type for state associated with the corresponding domain.

--- a/Sources/Store/Store.swift
+++ b/Sources/Store/Store.swift
@@ -16,7 +16,7 @@ public protocol Store<State, Action>: ObservableObject {
     associatedtype State: Sendable
 
     /// Usually represented as an `enum`, `Action` represents any functionality that a store can perform on-demand.
-    associatedtype Action
+    associatedtype Action: Sendable
 
     /// Single source of truth that is used to respresent the current state of the domain.
     var state: State { get }

--- a/ViewStore.xcodeproj/project.pbxproj
+++ b/ViewStore.xcodeproj/project.pbxproj
@@ -577,6 +577,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.lickability.ViewStore;
 				PRODUCT_NAME = ViewStore;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -606,6 +607,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.lickability.ViewStore;
 				PRODUCT_NAME = ViewStore;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/ViewStore.xcodeproj/project.pbxproj
+++ b/ViewStore.xcodeproj/project.pbxproj
@@ -413,7 +413,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.lickability.ViewStoreTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ViewStore.app/ViewStore";
 			};
@@ -431,7 +431,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = net.lickability.ViewStoreTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ViewStore.app/ViewStore";
 			};
@@ -495,6 +495,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Debug;
 		};
@@ -549,6 +550,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_STRICT_CONCURRENCY = complete;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -578,7 +580,7 @@
 				PRODUCT_NAME = ViewStore;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -608,7 +610,7 @@
 				PRODUCT_NAME = ViewStore;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
## What it Does
- Updates for Swift 6 and strict concurrency requirements.
- Makes state and action sendable
- Makes Store have a `MainActor` requirement
- Makes the MainQueueScheduler have a `MainActor` requirement

## How I Tested
- Ran the examples app and made updates as needed.
